### PR TITLE
config: Gradle Maven Publishing updated to use maven-publish (instead of maven plugin)

### DIFF
--- a/.github/workflows/kubernetes-dashboard-publish.yml
+++ b/.github/workflows/kubernetes-dashboard-publish.yml
@@ -1,0 +1,27 @@
+name: Publish Kubernetes Dashboard
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish-image:
+    name: Publish Kubernetes Dashboard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Node
+        uses: actions/setup-node@v2.1.2
+      - name: Setup Java 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: '11'
+      - name: Build and Push
+        working-directory: ./quickstarts/quarkus-dashboard
+        run: |
+          mvn -Pbuild-frontend,native,k8s clean package k8s:build k8s:push        \
+          -Dcontainer.image.tag=${GITHUB_REF#refs/tags/v}                         \
+          -Djkube.docker.push.username=${{ secrets.DOCKER_USERNAME }}             \
+          -Djkube.docker.push.password=${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,4 +30,4 @@ jobs:
           ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.ORG_GRADLE_PROJECT_ossrhPassword }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_signingKey }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_signingPassword }}
-        run: ./gradlew uploadArchives -Psign
+        run: ./gradlew publish -Psign

--- a/apis/cert-manager/build.gradle
+++ b/apis/cert-manager/build.gradle
@@ -11,7 +11,7 @@ ext {
 }
 
 dependencies {
-  compile  project(':kubernetes-model')
+  api project(':kubernetes-model')
   compileOnly "org.projectlombok:lombok:$version_projectlombok"
   annotationProcessor "org.projectlombok:lombok:$version_projectlombok"
 }

--- a/apis/chaos-mesh/build.gradle
+++ b/apis/chaos-mesh/build.gradle
@@ -11,7 +11,7 @@ ext {
 }
 
 dependencies {
-  compile  project(':kubernetes-model')
+  api project(':kubernetes-model')
   compileOnly "org.projectlombok:lombok:$version_projectlombok"
   annotationProcessor "org.projectlombok:lombok:$version_projectlombok"
 }

--- a/apis/dapr/build.gradle
+++ b/apis/dapr/build.gradle
@@ -11,7 +11,7 @@ ext {
 }
 
 dependencies {
-  compile  project(':kubernetes-model')
+  api project(':kubernetes-model')
   compileOnly "org.projectlombok:lombok:$version_projectlombok"
   annotationProcessor "org.projectlombok:lombok:$version_projectlombok"
 }

--- a/apis/istio/build.gradle
+++ b/apis/istio/build.gradle
@@ -11,7 +11,7 @@ ext {
 }
 
 dependencies {
-  compile  project(':kubernetes-model')
+  api project(':kubernetes-model')
   compileOnly "org.projectlombok:lombok:$version_projectlombok"
   annotationProcessor "org.projectlombok:lombok:$version_projectlombok"
 }

--- a/apis/knative/build.gradle
+++ b/apis/knative/build.gradle
@@ -11,7 +11,7 @@ ext {
 }
 
 dependencies {
-  compile  project(':kubernetes-model')
+  api project(':kubernetes-model')
   compileOnly "org.projectlombok:lombok:$version_projectlombok"
   annotationProcessor "org.projectlombok:lombok:$version_projectlombok"
 }

--- a/apis/kudo/build.gradle
+++ b/apis/kudo/build.gradle
@@ -11,7 +11,7 @@ ext {
 }
 
 dependencies {
-  compile  project(':kubernetes-model')
+  api project(':kubernetes-model')
   compileOnly "org.projectlombok:lombok:$version_projectlombok"
   annotationProcessor "org.projectlombok:lombok:$version_projectlombok"
 }

--- a/apis/metrics-server/build.gradle
+++ b/apis/metrics-server/build.gradle
@@ -11,7 +11,7 @@ ext {
 }
 
 dependencies {
-  compile  project(':kubernetes-model')
+  api project(':kubernetes-model')
   compileOnly "org.projectlombok:lombok:$version_projectlombok"
   annotationProcessor "org.projectlombok:lombok:$version_projectlombok"
 }

--- a/apis/openshift/build.gradle
+++ b/apis/openshift/build.gradle
@@ -11,7 +11,7 @@ ext {
 }
 
 dependencies {
-  compile  project(':kubernetes-model')
+  api project(':kubernetes-model')
   compileOnly "org.projectlombok:lombok:$version_projectlombok"
   annotationProcessor "org.projectlombok:lombok:$version_projectlombok"
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -10,9 +10,9 @@ java {
 }
 
 dependencies {
-  compile gradleApi()
-  compile "com.samskivert:jmustache:$version_mustache"
-  compile "io.swagger.parser.v3:swagger-parser:$version_swagger_parser"
+  compileOnly gradleApi()
+  compileOnly "com.samskivert:jmustache:$version_mustache"
+  compileOnly "io.swagger.parser.v3:swagger-parser:$version_swagger_parser"
   compileOnly "org.projectlombok:lombok:$version_projectlombok"
   annotationProcessor "org.projectlombok:lombok:$version_projectlombok"
 }

--- a/kubernetes-api/build.gradle
+++ b/kubernetes-api/build.gradle
@@ -7,7 +7,7 @@ ext {
 }
 
 dependencies {
-  compile  project(':kubernetes-model')
+  api project(':kubernetes-model')
   compileOnly "org.projectlombok:lombok:$version_projectlombok"
   annotationProcessor "org.projectlombok:lombok:$version_projectlombok"
 }

--- a/kubernetes-client-api/build.gradle
+++ b/kubernetes-client-api/build.gradle
@@ -8,8 +8,8 @@ ext {
 
 dependencies {
   compileOnly "org.projectlombok:lombok:$version_projectlombok"
-  compile "com.squareup.retrofit2:converter-jackson:$version_retrofit"
-  compile "com.squareup.retrofit2:retrofit:$version_retrofit"
-  compile "io.reactivex.rxjava2:rxjava:$version_rxjava2"
+  api "com.squareup.retrofit2:converter-jackson:$version_retrofit"
+  api "com.squareup.retrofit2:retrofit:$version_retrofit"
+  api "io.reactivex.rxjava2:rxjava:$version_rxjava2"
   annotationProcessor "org.projectlombok:lombok:$version_projectlombok"
 }

--- a/kubernetes-client/build.gradle
+++ b/kubernetes-client/build.gradle
@@ -7,12 +7,12 @@ ext {
 }
 
 dependencies {
-  compile  project(':kubernetes-client-api')
+  api project(':kubernetes-client-api')
   compileOnly "org.projectlombok:lombok:$version_projectlombok"
-  compile "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$version_jackson"
-  compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$version_jackson"
-  compile "org.bouncycastle:bcprov-jdk15on:$version_bouncycastle"
-  compile "org.bouncycastle:bcpkix-jdk15on:$version_bouncycastle"
+  api "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$version_jackson"
+  api "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$version_jackson"
+  api "org.bouncycastle:bcprov-jdk15on:$version_bouncycastle"
+  api "org.bouncycastle:bcpkix-jdk15on:$version_bouncycastle"
   annotationProcessor "org.projectlombok:lombok:$version_projectlombok"
   testImplementation "org.junit.jupiter:junit-jupiter-api:$version_junit"
   testImplementation "org.assertj:assertj-core:$version_assertj"

--- a/kubernetes-model/build.gradle
+++ b/kubernetes-model/build.gradle
@@ -7,7 +7,7 @@ ext {
 }
 
 dependencies {
-  compile  project(':kubernetes-client-api')
+  api project(':kubernetes-client-api')
   compileOnly "com.fasterxml.jackson.core:jackson-databind:$version_jackson"
   compileOnly "org.projectlombok:lombok:$version_projectlombok"
   annotationProcessor "org.projectlombok:lombok:$version_projectlombok"

--- a/shared.gradle
+++ b/shared.gradle
@@ -7,7 +7,7 @@ ext {
   version_junit = '5.7.0'
   version_mockito = '3.7.0'
   version_mustache = '1.15'
-  version_projectlombok = '1.18.12'
+  version_projectlombok = '1.18.22'
   version_retrofit = '2.8.1'
   version_rxjava2 = '2.2.19'
   version_swagger_parser = '2.0.19'
@@ -31,19 +31,15 @@ ext.configurePublishing = { Project evaluatedProject ->
   if (!evaluatedProject.isPublishable || project.hasProperty("skipPublishing")) {
     return
   }
-  if (project.hasProperty("sign")) {
-    apply plugin: 'signing'
-    signing {
-      def signingKey = findProperty("signingKey")
-      def signingPassword = findProperty("signingPassword")
-      useInMemoryPgpKeys(signingKey, signingPassword)
-      sign configurations.archives
-    }
-  }
+  def delombokedSourceDir = "$buildDir/delombok"
+  def isRelease = version.endsWith('SNAPSHOT')
+  def ossrhUsername = findProperty("ossrhUsername")
+  def ossrhPassword = findProperty("ossrhPassword")
+  def releaseUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+  def snapshotUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
+  apply plugin: 'maven-publish'
   apply plugin: 'org.kordamp.gradle.jandex'
   jar.dependsOn jandex
-  apply plugin: 'maven'
-  def delombokedSourceDir = "$buildDir/delombok";
   task delombok(dependsOn: classes) {
     group = 'maven'
     inputs.dir projectDir.toPath().resolve("src").toFile()
@@ -52,7 +48,7 @@ ext.configurePublishing = { Project evaluatedProject ->
       ant.taskdef(
         name: 'delombok',
         classname: 'lombok.delombok.ant.Tasks$Delombok',
-        classpath: configurations.compile.asPath + ";" + configurations.compileOnly.asPath
+        classpath: configurations.compileClasspath.asPath + ";" + configurations.runtimeClasspath.asPath
       )
       ant.mkdir(dir: delombokedSourceDir)
       evaluatedProject.sourceSets.main.java.srcDirs.each { srcDir ->
@@ -63,7 +59,7 @@ ext.configurePublishing = { Project evaluatedProject ->
   task delombokedJavadoc(type: Javadoc, dependsOn: delombok) {
     group = 'maven'
     source = delombokedSourceDir
-    classpath = files(configurations.compile, configurations.compileOnly.asPath)
+    classpath = files(configurations.compileClasspath.asPath, configurations.runtimeClasspath.asPath)
   }
   task sourcesJar(type: Jar, dependsOn: classes) {
     group = 'maven'
@@ -78,50 +74,60 @@ ext.configurePublishing = { Project evaluatedProject ->
   task assemblePublication(dependsOn: [classes, assemble, sourcesJar, javadocJar]) {
     group = 'maven'
   }
-  install.group 'maven'
-  install.dependsOn assemblePublication
-  artifacts {
-    archives sourcesJar
-    archives javadocJar
+  java {
+    withJavadocJar()
+    withSourcesJar()
   }
-  def ossrhUsername = findProperty("ossrhUsername")
-  def ossrhPassword = findProperty("ossrhPassword")
-  uploadArchives {
+  publishing {
     repositories {
-      mavenDeployer {
-        beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
-        repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-          authentication(userName: ossrhUsername, password: ossrhPassword)
+      maven {
+        url = isRelease ? releaseUrl : snapshotUrl
+        credentials {
+          username = ossrhUsername
+          password = ossrhPassword
         }
-        snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-          authentication(userName: ossrhUsername, password: ossrhPassword)
-        }
-        pom.project {
-          name pomName
-          description pomDescription
-          url 'https://github.com/manusa/yakc'
-          packaging 'jar'
+      }
+    }
+    publications {
+      mavenJava(MavenPublication) {
+        from components.java
+        pom {
+          name = pomName
+          description = pomDescription
+          url = 'https://github.com/manusa/yakc'
+          packaging = 'jar'
           scm {
-            connection 'scm:git:git://github.com/manusa/yakc.git'
-            developerConnection 'scm:git:ssh://github.com:manusa/yakc.git'
-            url 'https://github.com/manusa/yakc'
+            connection = 'scm:git:git://github.com/manusa/yakc.git'
+            developerConnection = 'scm:git:ssh://github.com:manusa/yakc.git'
+            url = 'https://github.com/manusa/yakc'
           }
           licenses {
             license {
-              name 'The Apache License, Version 2.0'
-              url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+              name = 'The Apache License, Version 2.0'
+              url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
             }
           }
           developers {
             developer {
-              name 'Marc Nuri'
-              email 'marc@marcnuri.com'
+              name = 'Marc Nuri'
+              email = 'marc@marcnuri.com'
             }
           }
         }
       }
     }
-    uploadArchives.group 'maven'
-    uploadArchives.dependsOn install
+  }
+  publishToMavenLocal.group 'maven'
+  publishToMavenLocal.dependsOn assemblePublication
+  publish.group 'maven'
+  publish.dependsOn publishToMavenLocal
+  if (project.hasProperty("sign")) {
+    apply plugin: 'signing'
+    signing {
+      def signingKey = findProperty("signingKey")
+      def signingPassword = findProperty("signingPassword")
+      useInMemoryPgpKeys(signingKey, signingPassword)
+      sign publishing.publications.mavenJava
+    }
   }
 }


### PR DESCRIPTION
Gradle maven plugin is deprecated and no longer supported in Gradle 7.
These changes configure the new maven-publish plugin and update
the signing plugin configuration.